### PR TITLE
Stan fix db conn issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/back-graphql/prisma/schema.prisma
+++ b/back-graphql/prisma/schema.prisma
@@ -8,7 +8,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = "postgresql://nhung:meomeo@localhost:5432/nest_db?schema=public"
+  url      = env("DB_URI")
 }
 
 model User {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - POSTGRES_USER=nhung
       - POSTGRES_PASSWORD=meomeo
       - POSGRES_DB=nest_db
+      - DB_URI=postgresql://postgres:meomeo@matcha-database:5432/postgres?schema=public
     restart: unless-stopped
     env_file: ./back-graphql/.env
     depends_on:


### PR DESCRIPTION
Problem was the use of localhost, each container has it own localhost, we have to use an external local ip addr, to find for example the ip address of the database container:

```shell
docker inspect nestjs_tutorial_matcha-database_1 | grep IPAddress
```

It's dynamic and change each time the container is rebuild. Docker provide an solution by autoreplacing the name of the container by it's local ip address.

Then the database and the user wasnt setup, only the password.

For the second commit, it's just to ignore node module if I installed it locally
